### PR TITLE
Feature: specialize pow/log operators for tensors

### DIFF
--- a/src/xpress/linalg.hpp
+++ b/src/xpress/linalg.hpp
@@ -355,4 +355,32 @@ struct subtraction_of<T1, T2> {
     }
 };
 
+template<xp::tensorial T>
+struct log_of<T> {
+    template<same_remove_cvref_t_as<T> _T>
+    constexpr auto operator()(_T&& t) const noexcept {
+        using scalar = scalar_type_t<T>;
+        using shape = linalg::traits::shape_of_t<T>;
+        linalg::tensor<scalar, shape> result{};
+        visit_indices_in(shape{}, [&] (const auto& idx) {
+            result[idx] = operators::log{}(xp::linalg::traits::access<T>::at(idx, t));
+        });
+        return result;
+    }
+};
+
+template<xp::tensorial T, typename E>
+struct power_of<T, E> {
+    template<same_remove_cvref_t_as<T> _T, same_remove_cvref_t_as<E> _E>
+    constexpr auto operator()(_T&& t, _E&& e) const noexcept {
+        using scalar = scalar_type_t<T>;
+        using shape = linalg::traits::shape_of_t<T>;
+        linalg::tensor<scalar, shape> result{};
+        visit_indices_in(shape{}, [&] (const auto& idx) {
+            result[idx] = operators::pow{}(xp::linalg::traits::access<T>::at(idx, t), e);
+        });
+        return result;
+    }
+};
+
 }  // namespace xp::operators::traits

--- a/test/test_tensor.cpp
+++ b/test/test_tensor.cpp
@@ -122,6 +122,20 @@ int main() {
         expect(eq(value_of(t1*t2, at(t1 = m, t2 = m)), 1+4+9+16));
     };
 
+    "tensor_log_operator"_test = [] () {
+        linalg::tensor m{shape<2, 2>, 1.0, 2.0, 3.0, 4.0};
+        linalg::tensor log_m{shape<2, 2>, std::log(1.0), std::log(2.0), std::log(3.0), std::log(4.0)};
+        const tensor t{shape<2, 2>};
+        expect(value_of(log(t), at(t = m)) == log_m);
+    };
+
+    "tensor_pow_operator"_test = [] () {
+        linalg::tensor m{shape<2, 2>, 1.0, 2.0, 3.0, 4.0};
+        linalg::tensor squared_m{shape<2, 2>, 1.0, 4.0, 9.0, 16.0};
+        const tensor t{shape<2, 2>};
+        expect(value_of(pow(t, val<2>), at(t = m)) == squared_m);
+    };
+
     "tensor_mat_mul"_test = [] () {
         tensor T{shape<2, 2>};
         vector<2> v{};


### PR DESCRIPTION
We simply do element-wise `pow` & `log`.