### PR TITLE
Feature: add operator[] for `derivatives`

### DIFF
--- a/src/xpress/derivatives.hpp
+++ b/src/xpress/derivatives.hpp
@@ -53,7 +53,14 @@ template<typename... D> requires(std::conjunction_v<detail::is_derivative<D>...>
 struct derivatives : private indexed<typename D::variable...> {
     constexpr derivatives(const D&...) noexcept {}
 
-    //! Return the derivative w.r.t. the given variable
+    //! Return the expression of the derivative w.r.t. the given variable
+    template<typename V>
+        requires(is_any_of_v<V, typename D::variable...>)
+    constexpr auto operator[](const V& var) const noexcept {
+        return wrt(var);
+    }
+
+    //! Return the expression of the derivative w.r.t. the given variable
     template<typename V>
         requires(is_any_of_v<V, typename D::variable...>)
     constexpr auto wrt(const V& var) const noexcept {

--- a/test/test_operators.cpp
+++ b/test/test_operators.cpp
@@ -195,10 +195,10 @@ int main() {
         static constexpr auto expression = val<42>*(a + val<2>*b) + c;
         static constexpr auto derivs = derivatives_of(expression, wrt(a, b, c));
 
-        // evaluation via value_of interface
-        static_assert(value_of(derivs.wrt(a), at(a = 0, b = 0, c = 0)) == 42);
-        static_assert(value_of(derivs.wrt(b), at(a = 0, b = 0, c = 0)) == 84);
-        static_assert(value_of(derivs.wrt(c), at(a = 0, b = 0, c = 0)) == 1);
+        // evaluation via value_of interface (test both [] and wrt())
+        static_assert(value_of(derivs[a], at(a = 0, b = 0, c = 0)) == 42);
+        static_assert(value_of(derivs[b], at(a = 0, b = 0, c = 0)) == 84);
+        static_assert(value_of(derivs[c], at(a = 0, b = 0, c = 0)) == 1);
         expect(eq(value_of(derivs.wrt(a), at(a = 0, b = 0, c = 0)), 42));
         expect(eq(value_of(derivs.wrt(b), at(a = 0, b = 0, c = 0)), 84));
         expect(eq(value_of(derivs.wrt(c), at(a = 0, b = 0, c = 0)), 1));


### PR DESCRIPTION
This streamlines the API of getting the derivative expressions vs. getting the values, i.e:

```cpp
auto exprs = derivatives_of(e, wrt(a, b));
auto de_da_expr = exprs[a];

auto vals = derivatives_of(e, wrt(a, b), at(a=..., b=...));
auto de_da = vals[a];
```