### PR TITLE
Feature: use shape as template arg in `tensor`

### DIFF
--- a/src/xpress/type_traits.hpp
+++ b/src/xpress/type_traits.hpp
@@ -38,7 +38,7 @@ inline constexpr bool is_indexable_v = is_indexable<T>::value;
 template<typename T>
 struct value_type;
 template<typename T> requires(is_indexable_v<T>)
-struct value_type<T> : std::type_identity<std::remove_cvref_t<decltype(T{}[std::size_t{0}])>> {};
+struct value_type<T> : std::type_identity<std::remove_cvref_t<decltype(std::declval<T>()[std::size_t{0}])>> {};
 template<typename T>
 using value_type_t = typename value_type<T>::type;
 


### PR DESCRIPTION
This makes it easier to specify some of the template args on the call site, for instance, you can write `tensor<md_shape<3, 3>, dtype::real>` to define a 3x3 tensor that only takes floating point values. Before, you would have had to define the lambda as well, i.e. `tensor<dtype_real, [](){}, 3, 3>`.