### PR TITLE
Cleanup: remove find_pkg statement in test folder

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -9,7 +9,6 @@ FetchContent_Declare(
 )
 FetchContent_MakeAvailable(ut)
 
-find_package(xpress)
 function (ad_add_test NAME SOURCE)
     add_executable(${NAME} ${SOURCE})
     target_link_libraries(${NAME} PRIVATE xpress::xpress Boost::ut)


### PR DESCRIPTION
Maybe this is a leftover from when the CI tested against the installed package in a different way.