### PR TITLE
Fix power operator derivative calculation

### DIFF
--- a/src/xpress/operators/pow.hpp
+++ b/src/xpress/operators/pow.hpp
@@ -72,7 +72,7 @@ struct derivative_of<operation<operators::pow, T1, T2>> {
     template<typename V>
     static constexpr auto wrt(const type_list<V>& var) noexcept {
         return T2{}*pow(T1{}, T2{} - val<1>)*xp::detail::differentiate<T1>(var)
-            + pow(T1{}, T2{})*log(T2{})*xp::detail::differentiate<T2>(var);
+            + pow(T1{}, T2{})*log(T1{})*xp::detail::differentiate<T2>(var);
     }
 };
 

--- a/test/test_operators.cpp
+++ b/test/test_operators.cpp
@@ -167,7 +167,7 @@ int main() {
         var a;
         let b;
         expect(eq(derivative_of(pow(a, b), wrt(a), at(a = 2, b = 3)), 3*2*2));
-        expect(eq(derivative_of(pow(a, b), wrt(b), at(a = 2, b = 3)), 2*2*2*std::log(3)));
+        expect(eq(derivative_of(pow(a, b), wrt(b), at(a = 2, b = 3)), 2*2*2*std::log(2)));
     };
 
     "log_operator"_test = [] () {


### PR DESCRIPTION
The correct derivative of a^b wrt to b is: 
d/db(a^b) = a^b*ln(a)

The previous implementation used ln(b) instead of ln(a). I changed:
1. The implementation in the power operator derivative
2. The reference solution in the test

@dglaeser if there are other tests that use the expression above, their reference solutions would need to be updated as well.